### PR TITLE
Add Application Command Router and Migrator

### DIFF
--- a/bot_stage_test.go
+++ b/bot_stage_test.go
@@ -23,7 +23,6 @@ type RunStage struct {
 	session *discordgo.Session
 	builder *Builder
 	bot     *Bot
-	router  *interactions.Router
 
 	ctx            context.Context
 	cancel         context.CancelFunc
@@ -31,7 +30,7 @@ type RunStage struct {
 	ready          *discordgo.Ready
 	connected      bool
 	healthAddr     string
-	applicationID  string // todo applicationID is unreliable as it doesn't correllate with the session ID
+	applicationID  string
 	createdCommand *discordgo.ApplicationCommand
 	guild          *discordgo.Guild
 	channel        *discordgo.Channel
@@ -77,17 +76,12 @@ func NewBotStage(t *testing.T) (*RunStage, *RunStage, *RunStage) {
 
 	// create a default test channel
 	s.channel, err = s.session.GuildChannelCreate(s.guild.ID, "test", discordgo.ChannelTypeGuildText)
+	s.require.NoError(err)
 
 	return s, s, s
 }
 
 func (s *RunStage) and() *RunStage {
-	return s
-}
-
-func (s *RunStage) a_new_bot() *RunStage {
-	s.builder = New(s.applicationID, s.session)
-
 	return s
 }
 
@@ -213,14 +207,6 @@ func (s *RunStage) an_application_command_already_exists_named(name string) *Run
 		Name: name,
 		Type: discordgo.ChatApplicationCommand,
 	})
-	s.require.NoError(err)
-
-	return s
-}
-
-func (s *RunStage) a_guild_named(name string) *RunStage {
-	var err error
-	s.guild, err = s.session.GuildCreate(name)
 	s.require.NoError(err)
 
 	return s

--- a/bot_stage_test.go
+++ b/bot_stage_test.go
@@ -3,13 +3,15 @@ package bot
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/elliotwms/bot/interactions"
+	"github.com/elliotwms/fakediscord/pkg/fakediscord"
+	"github.com/neilotoole/slogt"
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/require"
 )
@@ -18,20 +20,31 @@ type RunStage struct {
 	t       *testing.T
 	require *require.Assertions
 
-	session    *discordgo.Session
-	bot        *Bot
-	ctx        context.Context
-	cancel     context.CancelFunc
-	runResult  error
-	ready      *discordgo.Ready
-	connected  bool
-	healthAddr string
+	session *discordgo.Session
+	builder *Builder
+	bot     *Bot
+	router  *interactions.Router
+
+	ctx            context.Context
+	cancel         context.CancelFunc
+	runResult      error
+	ready          *discordgo.Ready
+	connected      bool
+	healthAddr     string
+	applicationID  string // todo applicationID is unreliable as it doesn't correllate with the session ID
+	createdCommand *discordgo.ApplicationCommand
+	guild          *discordgo.Guild
+	channel        *discordgo.Channel
+	handlerCalls   []*discordgo.InteractionCreate
+	fakediscord    *fakediscord.Client
+	interaction    *discordgo.InteractionCreate
 }
 
-func NewRunStage(t *testing.T) (*RunStage, *RunStage, *RunStage) {
+func NewBotStage(t *testing.T) (*RunStage, *RunStage, *RunStage) {
 	s := &RunStage{
-		t:       t,
-		require: require.New(t),
+		t:             t,
+		require:       require.New(t),
+		applicationID: appID,
 	}
 
 	s.ctx, s.cancel = context.WithCancel(context.Background())
@@ -53,6 +66,18 @@ func NewRunStage(t *testing.T) (*RunStage, *RunStage, *RunStage) {
 		s.connected = false
 	})
 
+	s.fakediscord = fakediscord.NewClient("test")
+
+	// build the bot
+	s.builder = New(s.applicationID, s.session).WithLogger(slogt.New(s.t))
+
+	// create a default test guild
+	s.guild, err = s.session.GuildCreate(s.t.Name())
+	s.require.NoError(err)
+
+	// create a default test channel
+	s.channel, err = s.session.GuildChannelCreate(s.guild.ID, "test", discordgo.ChannelTypeGuildText)
+
 	return s, s, s
 }
 
@@ -61,34 +86,38 @@ func (s *RunStage) and() *RunStage {
 }
 
 func (s *RunStage) a_new_bot() *RunStage {
-	s.bot = New("id", s.session).WithLogger(slog.Default())
+	s.builder = New(s.applicationID, s.session)
 
 	return s
 }
 
-func (s *RunStage) with_custom_intents() {
-	s.bot.WithIntents(discordgo.IntentGuilds)
+func (s *RunStage) the_bot_has_custom_intents() {
+	s.builder.WithIntents(discordgo.IntentGuilds)
 }
 
-func (s *RunStage) with_health_check() {
+func (s *RunStage) the_bot_has_a_health_check_endpoint() {
 	port, err := freeport.GetFreePort()
 	s.require.NoError(err)
 
 	s.healthAddr = fmt.Sprintf("127.0.0.1:%d", port)
 
-	s.bot.WithHealthCheck(s.healthAddr)
+	s.builder.WithHealthCheck(s.healthAddr)
 }
 
-func (s *RunStage) the_bot_watches_for_ready_events() *RunStage {
-	s.bot.WithHandler(func(_ *discordgo.Session, r *discordgo.Ready) {
+func (s *RunStage) a_ready_event_is_expected() *RunStage {
+	cleanup := s.session.AddHandler(func(_ *discordgo.Session, r *discordgo.Ready) {
 		s.ready = r
 	})
+
+	s.t.Cleanup(cleanup)
 
 	return s
 }
 
 func (s *RunStage) the_bot_is_run() *RunStage {
 	go func() {
+		s.bot = s.builder.Build()
+
 		s.runResult = s.bot.Run(s.ctx)
 	}()
 
@@ -169,4 +198,130 @@ func (s *RunStage) the_health_check_should_succeed() {
 
 		return true
 	}, 5*time.Second, 100*time.Millisecond)
+}
+
+// cleanup for tests unrelated to connectivity
+func (s *RunStage) cleanup() {
+	s.
+		the_bot_is_stopped().and().
+		the_session_is_disconnected()
+}
+
+func (s *RunStage) an_application_command_already_exists_named(name string) *RunStage {
+	var err error
+	s.createdCommand, err = s.session.ApplicationCommandCreate(s.applicationID, "", &discordgo.ApplicationCommand{
+		Name: name,
+		Type: discordgo.ChatApplicationCommand,
+	})
+	s.require.NoError(err)
+
+	return s
+}
+
+func (s *RunStage) a_guild_named(name string) *RunStage {
+	var err error
+	s.guild, err = s.session.GuildCreate(name)
+	s.require.NoError(err)
+
+	return s
+}
+
+func (s *RunStage) the_bot_has_application_command_named(name string) *RunStage {
+	s.builder.WithApplicationCommand(&discordgo.ApplicationCommand{Name: name, Type: discordgo.ChatApplicationCommand}, func(_ *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ApplicationCommandInteractionData) (err error) {
+		s.t.Log("Handler called")
+		s.handlerCalls = append(s.handlerCalls, i)
+
+		return nil
+	})
+
+	return s
+}
+
+func (s *RunStage) a_command_should_exist_named(name string) *RunStage {
+	s.require.Eventually(func() bool {
+		commands, err := s.session.ApplicationCommands(s.applicationID, "")
+		if err != nil {
+			return false
+		}
+
+		for _, c := range commands {
+			if c.Name == name {
+				return true
+			}
+		}
+
+		return false
+	}, 1*time.Second, 100*time.Millisecond)
+
+	return s
+}
+
+func (s *RunStage) a_command_should_not_exist_named(name string) *RunStage {
+	s.require.Eventually(func() bool {
+		commands, err := s.session.ApplicationCommands(s.applicationID, "")
+		if err != nil {
+			return false
+		}
+
+		for _, c := range commands {
+			if c.Name == name {
+				return false
+			}
+		}
+
+		return true
+	}, 1*time.Second, 100*time.Millisecond)
+
+	return s
+}
+
+func (s *RunStage) migration_is_enabled() {
+	s.builder.WithMigrationEnabled(true)
+}
+
+func (s *RunStage) the_command_is_invoked(name string) *RunStage {
+	var err error
+	s.interaction, err = s.fakediscord.Interaction(&discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		AppID: s.applicationID,
+		Type:  discordgo.InteractionApplicationCommand,
+		Data: discordgo.ApplicationCommandInteractionData{
+			ID:          "id",
+			Name:        name,
+			CommandType: discordgo.ChatApplicationCommand,
+		},
+		ChannelID: s.channel.ID,
+		GuildID:   s.guild.ID,
+	}})
+
+	s.require.NoError(err)
+
+	return s
+}
+
+func (s *RunStage) the_bot_has_deferred_response_enabled() *RunStage {
+	r := interactions.NewRouter(interactions.WithDeferredResponse(true))
+	s.builder.WithRouter(r)
+
+	return s
+}
+
+func (s *RunStage) the_interaction_should_have_a_deferred_response() {
+	res, err := s.session.InteractionResponse(s.interaction.Interaction)
+	s.require.NoError(err)
+
+	s.require.Equal(discordgo.MessageTypeReply, res.Type)
+	s.require.Equal(discordgo.MessageFlagsLoading, res.Flags)
+}
+
+func (s *RunStage) the_command_handler_should_have_been_called() *RunStage {
+	s.require.Eventually(
+		func() bool {
+			return len(s.handlerCalls) > 0
+		},
+		1*time.Second,
+		10*time.Millisecond,
+		"the handler should have been called at least once",
+	)
+
+	return s
 }

--- a/bot_test.go
+++ b/bot_test.go
@@ -96,15 +96,15 @@ func TestBot_WithCommand_MigrationDisabled(t *testing.T) {
 	t.Cleanup(then.cleanup)
 
 	given.
-		an_application_command_already_exists_named("foo").and().
-		the_bot_has_application_command_named("bar")
+		an_application_command_already_exists_named("baz").and().
+		the_bot_has_application_command_named("bux")
 
 	when.
 		the_bot_is_run()
 
 	then.
-		a_command_should_exist_named("foo").and().
-		a_command_should_not_exist_named("bar")
+		a_command_should_exist_named("baz").and().
+		a_command_should_not_exist_named("bux")
 }
 
 func TestBot_WithCommand_WithDeferredResponse(t *testing.T) {

--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,149 @@
+package bot
+
+import (
+	"log/slog"
+	"maps"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/elliotwms/bot/interactions"
+	"github.com/elliotwms/bot/log"
+)
+
+// Builder builds a Bot.
+// To enable application command migration, either set a specific migrator with WithMigrator or set
+// WithMigrationEnabled and a default Migrator will be created based on the Bot's configuration.
+type Builder struct {
+	session          *discordgo.Session
+	log              *slog.Logger
+	applicationID    string
+	healthCheckAddr  *string
+	intents          discordgo.Intent
+	handlerRemovers  []func()
+	router           *interactions.Router
+	migrator         *interactions.Migrator
+	guildID          string
+	handlers         []interface{}
+	commands         map[*discordgo.ApplicationCommand]interactions.ApplicationCommandHandler
+	migrationEnabled bool
+}
+
+func New(applicationID string, session *discordgo.Session) *Builder {
+	bot := &Builder{
+		session:       session,
+		log:           slog.New(log.DiscardHandler),
+		applicationID: applicationID,
+		commands:      make(map[*discordgo.ApplicationCommand]interactions.ApplicationCommandHandler),
+	}
+
+	return bot
+}
+
+func (b *Builder) WithLogger(l *slog.Logger) *Builder {
+	b.log = l
+
+	return b
+
+}
+func (b *Builder) WithIntents(i discordgo.Intent) *Builder {
+	b.intents = i
+
+	return b
+
+}
+
+func (b *Builder) WithHealthCheck(addr string) *Builder {
+	b.healthCheckAddr = &addr
+
+	return b
+}
+
+func (b *Builder) WithHandler(h interface{}) *Builder {
+	b.handlers = append(b.handlers, h)
+
+	return b
+}
+
+func (b *Builder) WithHandlers(hs []interface{}) *Builder {
+	for _, h := range hs {
+		b.WithHandler(h)
+	}
+
+	return b
+}
+
+func (b *Builder) WithRouter(r *interactions.Router) *Builder {
+	b.router = r
+
+	return b
+}
+
+func (b *Builder) WithMigrator(m *interactions.Migrator) *Builder {
+	b.migrator = m
+
+	return b
+}
+
+func (b *Builder) WithGuildID(guildID string) *Builder {
+	b.guildID = guildID
+
+	return b
+}
+
+func (b *Builder) WithMigrationEnabled(enabled bool) *Builder {
+	b.migrationEnabled = enabled
+
+	return b
+}
+
+func (b *Builder) WithApplicationCommand(c *discordgo.ApplicationCommand, h interactions.ApplicationCommandHandler) *Builder {
+	b.commands[c] = h
+
+	return b
+}
+
+func (b *Builder) WithApplicationCommands(handlers map[*discordgo.ApplicationCommand]interactions.ApplicationCommandHandler) *Builder {
+	maps.Copy(b.commands, handlers)
+
+	return b
+}
+
+func (b *Builder) Build() *Bot {
+	bot := &Bot{
+		session:         b.session,
+		log:             b.log,
+		applicationID:   b.applicationID,
+		healthCheckAddr: b.healthCheckAddr,
+		intents:         b.intents,
+		router:          b.router,
+		migrator:        b.migrator,
+	}
+
+	for _, h := range b.handlers {
+		bot.handlerRemovers = append(bot.handlerRemovers, bot.session.AddHandler(h))
+	}
+
+	// register application commands with the router and migrator
+	if len(b.commands) > 0 {
+		if bot.router == nil {
+			bot.router = interactions.NewRouter(interactions.WithLogger(bot.log))
+		}
+
+		if bot.migrator == nil && b.migrationEnabled {
+			bot.migrator = interactions.NewMigrator(
+				b.session,
+				b.applicationID,
+				interactions.WithGuildID(b.guildID),
+			)
+		}
+
+		for c, h := range b.commands {
+			bot.router.RegisterCommand(c.Name, c.Type, h)
+
+			if bot.migrator != nil {
+				bot.migrator.WithApplicationCommand(c)
+			}
+		}
+	}
+
+	return bot
+}

--- a/builder.go
+++ b/builder.go
@@ -18,7 +18,6 @@ type Builder struct {
 	applicationID    string
 	healthCheckAddr  *string
 	intents          discordgo.Intent
-	handlerRemovers  []func()
 	router           *interactions.Router
 	migrator         *interactions.Migrator
 	guildID          string

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   fake-discord:
-    image: ghcr.io/elliotwms/fakediscord:v0.17.0
+    image: ghcr.io/elliotwms/fakediscord:v0.18.2
     ports:
       - 8080:8080
     volumes:

--- a/fakediscord.yaml
+++ b/fakediscord.yaml
@@ -1,5 +1,6 @@
 users:
   - username: Bot
+    id: 1881067102262001664
     discriminator: "0451"
     bot: true
     token: token

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23
 require (
 	github.com/bwmarrin/discordgo v0.28.1
 	github.com/elliotwms/fakediscord v0.17.0
+	github.com/neilotoole/slogt v1.1.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/stretchr/testify v1.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/elliotwms/fakediscord v0.17.0/go.mod h1:diPjfnMTjg73Izwl5pHMvGoGuOL8V
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/neilotoole/slogt v1.1.0 h1:c7qE92sq+V0yvCuaxph+RQ2jOKL61c4hqS1Bv9W7FZE=
+github.com/neilotoole/slogt v1.1.0/go.mod h1:RCrGXkPc/hYybNulqQrMHRtvlQ7F6NktNVLuLwk6V+w=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/health_check.go
+++ b/health_check.go
@@ -7,12 +7,6 @@ import (
 	"github.com/elliotwms/bot/log"
 )
 
-func (bot *Bot) WithHealthCheck(addr string) *Bot {
-	bot.healthCheckAddr = &addr
-
-	return bot
-}
-
 func (bot *Bot) httpListen() {
 	http.HandleFunc("/v1/health", func(w http.ResponseWriter, req *http.Request) {
 		bot.log.Debug("Health check")

--- a/health_check.go
+++ b/health_check.go
@@ -3,6 +3,8 @@ package bot
 import (
 	"net/http"
 	"time"
+
+	"github.com/elliotwms/bot/log"
 )
 
 func (bot *Bot) WithHealthCheck(addr string) *Bot {
@@ -21,7 +23,7 @@ func (bot *Bot) httpListen() {
 		}
 
 		if _, err := w.Write([]byte(latency.String())); err != nil {
-			bot.log.Error("Could not write health check response", withErr(err))
+			bot.log.Error("Could not write health check response", log.WithErr(err))
 		}
 	})
 
@@ -29,7 +31,7 @@ func (bot *Bot) httpListen() {
 
 	err := http.ListenAndServe(*bot.healthCheckAddr, nil)
 	if err != nil {
-		bot.log.Error("Could not serve health check endpoint", withErr(err))
+		bot.log.Error("Could not serve health check endpoint", log.WithErr(err))
 		return
 	}
 }

--- a/interactions/migrator.go
+++ b/interactions/migrator.go
@@ -1,0 +1,56 @@
+package interactions
+
+import (
+	"context"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+type commandUpdater interface {
+	ApplicationCommandBulkOverwrite(appID, guildID string, commands []*discordgo.ApplicationCommand, opts ...discordgo.RequestOption) ([]*discordgo.ApplicationCommand, error)
+}
+
+// Migrator migrates application commands for a given application. It can also be provided with a guild ID (see
+// WithGuildID), which can be used during testing to create the commands within a test guild instead.
+type Migrator struct {
+	s        commandUpdater
+	appID    string
+	commands []*discordgo.ApplicationCommand
+	guildID  string
+
+	shouldDeleteStaleCommands bool
+}
+
+type MigratorOption func(*Migrator)
+
+// NewMigrator creates a new Migrator.
+func NewMigrator(s *discordgo.Session, appID string, opts ...MigratorOption) *Migrator {
+	m := &Migrator{s: s, appID: appID}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+// WithGuildID configures a guild to create the commands in (as opposed to creating them globally).
+func WithGuildID(id string) MigratorOption {
+	return func(migrator *Migrator) {
+		migrator.guildID = id
+	}
+}
+
+// WithApplicationCommand registers an application command to be migrated when Migrate is called.
+func (m *Migrator) WithApplicationCommand(c *discordgo.ApplicationCommand) *Migrator {
+	m.commands = append(m.commands, c)
+
+	return m
+}
+
+// Migrate migrates the application's commands.
+func (m *Migrator) Migrate(ctx context.Context) error {
+	_, err := m.s.ApplicationCommandBulkOverwrite(m.appID, m.guildID, m.commands, discordgo.WithContext(ctx))
+
+	return err
+}

--- a/interactions/migrator.go
+++ b/interactions/migrator.go
@@ -17,8 +17,6 @@ type Migrator struct {
 	appID    string
 	commands []*discordgo.ApplicationCommand
 	guildID  string
-
-	shouldDeleteStaleCommands bool
 }
 
 type MigratorOption func(*Migrator)

--- a/interactions/migrator_test.go
+++ b/interactions/migrator_test.go
@@ -1,0 +1,69 @@
+package interactions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrator_NewMigrator(t *testing.T) {
+	s, _ := discordgo.New("token")
+
+	m := NewMigrator(s, "foo")
+
+	require.Empty(t, m.guildID)
+}
+
+func TestMigrator_NewMigrator_WithGuildID(t *testing.T) {
+	s, _ := discordgo.New("token")
+
+	m := NewMigrator(s, "foo", WithGuildID("bar"))
+
+	require.Equal(t, "bar", m.guildID)
+}
+
+func TestMigrator_Migrate(t *testing.T) {
+	tests := map[string]string{
+		"no guild id":   "",
+		"with guild id": "guildid",
+	}
+
+	for k, v := range tests {
+		t.Run(k, func(t *testing.T) {
+			updater := &testCommandUpdater{}
+			m := &Migrator{
+				s:       updater,
+				appID:   "foo",
+				guildID: v,
+			}
+
+			m.WithApplicationCommand(&discordgo.ApplicationCommand{})
+
+			err := m.Migrate(context.Background())
+
+			require.NoError(t, err)
+			require.Equal(t, 1, updater.calls)
+			require.Equal(t, "foo", updater.appID)
+			require.Equal(t, v, updater.guildID)
+			require.Len(t, updater.commands, 1)
+		})
+	}
+}
+
+type testCommandUpdater struct {
+	calls    int
+	appID    string
+	guildID  string
+	commands []*discordgo.ApplicationCommand
+}
+
+func (t *testCommandUpdater) ApplicationCommandBulkOverwrite(appID, guildID string, commands []*discordgo.ApplicationCommand, opts ...discordgo.RequestOption) ([]*discordgo.ApplicationCommand, error) {
+	t.calls++
+
+	t.appID, t.guildID = appID, guildID
+	t.commands = commands
+
+	return commands, nil
+}

--- a/interactions/router.go
+++ b/interactions/router.go
@@ -1,0 +1,90 @@
+package interactions
+
+import (
+	"log/slog"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/elliotwms/bot/log"
+)
+
+type ApplicationCommandHandler func(s *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ApplicationCommandInteractionData) (err error)
+
+type Router struct {
+	applicationCommandHandlers map[string]ApplicationCommandHandler
+	log                        *slog.Logger
+	deferredResponseEnabled    bool
+}
+
+func NewRouter(options ...func(*Router)) *Router {
+	r := &Router{
+		applicationCommandHandlers: make(map[string]ApplicationCommandHandler),
+		log:                        slog.New(log.DiscardHandler),
+	}
+
+	for _, o := range options {
+		o(r)
+	}
+
+	return r
+}
+
+func WithLogger(l *slog.Logger) func(*Router) {
+	return func(r *Router) {
+		r.log = l
+	}
+}
+
+func WithDeferredResponse(enabled bool) func(*Router) {
+	return func(r *Router) {
+		r.deferredResponseEnabled = enabled
+	}
+}
+
+func WithCommandHandler(name string, handler ApplicationCommandHandler) func(*Router) {
+	return func(r *Router) {
+		r.RegisterCommand(name, handler)
+	}
+}
+
+func (r *Router) RegisterCommand(name string, handler ApplicationCommandHandler) {
+	r.applicationCommandHandlers[name] = handler
+}
+
+// Handle implements the discordgo.InteractionCreate handler, dispatching events to the relevant handlers within the
+// router. Currently only application commands are supported
+func (r *Router) Handle(s *discordgo.Session, e *discordgo.InteractionCreate) {
+	// todo handle other interaction types
+	switch e.Type {
+	case discordgo.InteractionApplicationCommand:
+		r.handleApplicationCommand(s, e)
+	default:
+		r.log.Error("Unexpected interaction type", "type", e.Type.String())
+	}
+}
+
+func (r *Router) handleApplicationCommand(s *discordgo.Session, e *discordgo.InteractionCreate) {
+	if r.deferredResponseEnabled {
+		err := s.InteractionRespond(e.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		if err != nil {
+			r.log.Error("Failed to respond to InteractionCreate", "error", err)
+			return
+		}
+	}
+
+	command := e.ApplicationCommandData()
+
+	h, ok := r.applicationCommandHandlers[command.Name]
+	if !ok {
+		r.log.Error("Handler not found for application command", "name", command.Name)
+		return
+	}
+
+	if err := h(s, e, command); err != nil {
+		r.log.Error("Failed to handle interaction", "error", err)
+	}
+}

--- a/interactions/router_stage_test.go
+++ b/interactions/router_stage_test.go
@@ -26,10 +26,6 @@ func NewRouterStage(t *testing.T) (*RouterStage, *RouterStage, *RouterStage) {
 	return s, s, s
 }
 
-func (s *RouterStage) and() *RouterStage {
-	return s
-}
-
 func (s *RouterStage) a_handler_is_registered_for_command(name string) {
 	s.router.RegisterCommand(name, discordgo.ChatApplicationCommand, func(_ *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ApplicationCommandInteractionData) (err error) {
 		s.handlerCalled++

--- a/interactions/router_stage_test.go
+++ b/interactions/router_stage_test.go
@@ -1,0 +1,54 @@
+package interactions
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/require"
+)
+
+type RouterStage struct {
+	t       testing.TB
+	require *require.Assertions
+
+	router        *Router
+	handlerCalled int
+}
+
+func NewRouterStage(t *testing.T) (*RouterStage, *RouterStage, *RouterStage) {
+	s := &RouterStage{
+		t:       t,
+		require: require.New(t),
+		router:  NewRouter(WithLogger(slog.Default())),
+	}
+
+	return s, s, s
+}
+
+func (s *RouterStage) and() *RouterStage {
+	return s
+}
+
+func (s *RouterStage) a_handler_is_registered_for_command(name string) {
+	s.router.RegisterCommand(name, func(_ *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ApplicationCommandInteractionData) (err error) {
+		s.handlerCalled++
+
+		return nil
+	})
+}
+
+func (s *RouterStage) the_router_is_called_for_command(name string) {
+	s.router.Handle(nil, &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{
+				Name: name,
+			},
+		},
+	})
+}
+
+func (s *RouterStage) the_handler_should_have_been_called_n_times(i int) {
+	s.require.Equal(i, s.handlerCalled)
+}

--- a/interactions/router_stage_test.go
+++ b/interactions/router_stage_test.go
@@ -31,7 +31,7 @@ func (s *RouterStage) and() *RouterStage {
 }
 
 func (s *RouterStage) a_handler_is_registered_for_command(name string) {
-	s.router.RegisterCommand(name, func(_ *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ApplicationCommandInteractionData) (err error) {
+	s.router.RegisterCommand(name, discordgo.ChatApplicationCommand, func(_ *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ApplicationCommandInteractionData) (err error) {
 		s.handlerCalled++
 
 		return nil
@@ -43,7 +43,8 @@ func (s *RouterStage) the_router_is_called_for_command(name string) {
 		Interaction: &discordgo.Interaction{
 			Type: discordgo.InteractionApplicationCommand,
 			Data: discordgo.ApplicationCommandInteractionData{
-				Name: name,
+				Name:        name,
+				CommandType: discordgo.ChatApplicationCommand,
 			},
 		},
 	})

--- a/interactions/router_test.go
+++ b/interactions/router_test.go
@@ -1,0 +1,32 @@
+package interactions
+
+import (
+	"testing"
+)
+
+func TestRouter_ApplicationCommand(t *testing.T) {
+	given, when, then := NewRouterStage(t)
+
+	given.
+		a_handler_is_registered_for_command("foo")
+
+	when.
+		the_router_is_called_for_command("foo")
+
+	then.
+		the_handler_should_have_been_called_n_times(1)
+
+}
+
+func TestRouter_ApplicationCommand_NotFound(t *testing.T) {
+	given, when, then := NewRouterStage(t)
+
+	given.
+		a_handler_is_registered_for_command("foo")
+
+	when.
+		the_router_is_called_for_command("bar")
+
+	then.
+		the_handler_should_have_been_called_n_times(0)
+}

--- a/log/log.go
+++ b/log/log.go
@@ -1,14 +1,14 @@
-package bot
+package log
 
 import (
 	"context"
 	"log/slog"
 )
 
-// dh discards all log output.
-// dh.Enabled returns false for all Levels.
+// DiscardHandler discards all log output.
+// DiscardHandler.Enabled returns false for all Levels.
 // todo remove when slog.DiscardHandler is available in go 1.24 https://github.com/golang/go/issues/62005
-var dh slog.Handler = discardHandler{}
+var DiscardHandler slog.Handler = discardHandler{}
 
 type discardHandler struct{}
 
@@ -17,6 +17,6 @@ func (dh discardHandler) Handle(context.Context, slog.Record) error { return nil
 func (dh discardHandler) WithAttrs(attrs []slog.Attr) slog.Handler  { return dh }
 func (dh discardHandler) WithGroup(name string) slog.Handler        { return dh }
 
-func withErr(err error) slog.Attr {
+func WithErr(err error) slog.Attr {
 	return slog.Any("error", err)
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,0 +1,14 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/elliotwms/fakediscord/pkg/fakediscord"
+)
+
+const appID = "1881067102262001664"
+
+func TestMain(m *testing.M) {
+	fakediscord.Configure("http://localhost:8080/")
+	m.Run()
+}


### PR DESCRIPTION
This PR adds a router and migrator for application commands, and integrates them as configurable parts of the default `Bot`. It also adds a `Builder` for correctly building the `Bot` itself